### PR TITLE
Option to only show limited permissions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Edit your Django project's settings module, and add ``groot``:
 Usage
 -----
 
-Add `GrootAdminMixin` to the admin class you want Groot to be used on:
+Add ``GrootAdminMixin`` to the admin class you want Groot to be used on:
 
 .. code-block:: python
 
@@ -48,5 +48,12 @@ Add `GrootAdminMixin` to the admin class you want Groot to be used on:
 
 
     @admin.register(Post)
-    class PostAdmin(GrootAdminMixin, BasePageAdmin):
+    class PostAdmin(GrootAdminMixin, admin.ModelAdmin):
         pass
+
+To limit the permissions which can be edited, add a ``groot_permissions`` attribute:
+
+.. code-block:: python
+
+    class PostAdmin(GrootAdminMixin, admin.ModelAdmin):
+        groot_permissions = ('change_post', 'delete_post')

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,33 @@
+from __future__ import unicode_literals
+
+from django.contrib.admin import AdminSite
+from django.test import TestCase
+
+from .admin import AuthorAdmin
+from .models import Author
+
+
+class TestGetGrootPermissions(TestCase):
+    def setUp(self):
+        self.site = AdminSite(name='admin')
+
+    def test_default_perms(self):
+        self.site.register(Author, AuthorAdmin)
+        author_admin = self.site._registry[Author]
+
+        permissions = author_admin.get_groot_permissions(request=None)
+
+        self.assertListEqual(
+            list(permissions.values_list('codename', flat=True)),
+            ['add_author', 'change_author', 'delete_author'],
+        )
+
+    def test_limited_perms(self):
+        self.site.register(Author, AuthorAdmin, groot_permissions=('add_author',))
+        author_admin = self.site._registry[Author]
+
+        permissions = author_admin.get_groot_permissions(request=None)
+
+        self.assertListEqual(
+            list(permissions.values_list('codename', flat=True)), ['add_author'],
+        )


### PR DESCRIPTION
Sometimes it makes sense to only allow admin to edit object level permissions for specific permissions - this gives us the option to define this as part of the admin class.