### PR TITLE
Only show "Group Permissions" link to superusers

### DIFF
--- a/groot/templates/admin/groot_change_form.html
+++ b/groot/templates/admin/groot_change_form.html
@@ -4,11 +4,13 @@
 
 
 {% block object-tools-items %}
-  <li>
-    {% url opts|admin_urlname:'groot' original.pk|admin_urlquote as groot_url %}
-    <a href="{% add_preserved_filters groot_url %}" class="grootlink">
-      {% trans 'Group Permissions' %}
-    </a>
-  </li>
+  {% if user.is_superuser %}
+    <li>
+      {% url opts|admin_urlname:'groot' original.pk|admin_urlquote as groot_url %}
+      <a href="{% add_preserved_filters groot_url %}" class="grootlink">
+        {% trans 'Group Permissions' %}
+      </a>
+    </li>
+  {% endif %}
   {{ block.super }}
 {% endblock object-tools-items %}

--- a/groot/templates/admin/groot_change_form.html
+++ b/groot/templates/admin/groot_change_form.html
@@ -1,11 +1,14 @@
-{% extends "admin/change_form.html" %}
-{% load i18n admin_urls %}
+{% extends 'admin/change_form.html' %}
+{% load admin_urls %}
+{% load i18n %}
 
 
 {% block object-tools-items %}
-<li>
+  <li>
     {% url opts|admin_urlname:'groot' original.pk|admin_urlquote as groot_url %}
-    <a href="{% add_preserved_filters groot_url %}" class="grootlink">{% trans "Group Permissions" %}</a>
-</li>
-{{ block.super }}
+    <a href="{% add_preserved_filters groot_url %}" class="grootlink">
+      {% trans 'Group Permissions' %}
+    </a>
+  </li>
+  {{ block.super }}
 {% endblock object-tools-items %}

--- a/groot/templates/admin/group_permissions.html
+++ b/groot/templates/admin/group_permissions.html
@@ -1,17 +1,20 @@
-{% extends "admin/base_site.html" %}
-{% load i18n l10n admin_urls static %}
+{% extends 'admin/base_site.html' %}
+{% load admin_urls %}
+{% load l10n %}
+{% load i18n %}
+{% load static %}
 
 
 {% block extrahead %}
-{{ block.super }}
-<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
-{{ form.media }}
+  {{ block.super }}
+  <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+  {{ form.media }}
 {% endblock extrahead %}
 
 
 {% block extrastyle %}
-{{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
 {% endblock extrastyle %}
 
 
@@ -19,76 +22,76 @@
 
 
 {% block breadcrumbs %}
-<div class="breadcrumbs">
-    <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
     &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
     &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
-    &rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
-    &rsaquo; {% trans "Group permissions" %}
-</div>
+    &rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:'18' }}</a>
+    &rsaquo; {% trans 'Group permissions' %}
+  </div>
 {% endblock breadcrumbs %}
 
 
 {% block content %}
-{% if formset.total_error_count %}
+  {% if formset.total_error_count %}
     <p class="errornote">
-        {% if formset.total_error_count == 1 %}
-            {% trans "Please correct the error below." %}
-        {% else %}
-            {% trans "Please correct the errors below." %}
-        {% endif %}
+      {% if formset.total_error_count == 1 %}
+        {% trans 'Please correct the error below.' %}
+      {% else %}
+        {% trans 'Please correct the errors below.' %}
+      {% endif %}
     </p>
 
     {{ formset.non_form_errors }}
 
     {% for group, form in group_formsets %}
-        {% if form.errors %}
-            <div class="form-row errors">
-                <p><strong>{{ group }}</strong></p>
-                {% for field, field_errors in form.errors.items %}
-                    {{ field_errors }}
-                {% endfor %}
-            </div>
-        {% endif %}
+      {% if form.errors %}
+        <div class="form-row errors">
+          <p><strong>{{ group }}</strong></p>
+          {% for field, field_errors in form.errors.items %}
+            {{ field_errors }}
+          {% endfor %}
+        </div>
+      {% endif %}
     {% endfor %}
 
     <br>
-{% endif %}
+  {% endif %}
 
-<form action="" method="POST" id="group-permissions">
+  <form action="" method="POST" id="group-permissions">
     {% csrf_token %}
 
     {{ formset.management_form }}
 
     <fieldset class="module aligned {{ fieldset.classes }}">
-        <table>
-            <thead>
-                <tr>
-                    <th>{% trans "Group" %}</th>
-                    {% for field in formset.empty_form.visible_fields %}
-                        <th>{{ field.label }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            {% for group, form in group_formsets %}
-                <tr>
-                    <th scope="row">
-                        {{ group }}
-
-                        {% for field in form.hidden_fields %}
-                            {{ field }}
-                        {% endfor %}
-                    </th>
-                    {% for field in form.visible_fields %}
-                        <td>{{ field }}</td>
-                    {% endfor %}
-                </tr>
+      <table>
+        <thead>
+          <tr>
+            <th>{% trans 'Group' %}</th>
+            {% for field in formset.empty_form.visible_fields %}
+              <th>{{ field.label }}</th>
             {% endfor %}
-        </table>
+          </tr>
+        </thead>
+        {% for group, form in group_formsets %}
+          <tr>
+            <th scope="row">
+              {{ group }}
+
+              {% for field in form.hidden_fields %}
+                {{ field }}
+              {% endfor %}
+            </th>
+            {% for field in form.visible_fields %}
+              <td>{{ field }}</td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </table>
     </fieldset>
 
     <div>
-        <input type="submit" value="{% trans 'Update permissions' %}" />
+      <input type="submit" value="{% trans 'Update permissions' %}" />
     </div>
-</form>
+  </form>
 {% endblock content %}

--- a/groot/templates/admin/update_permissions.html
+++ b/groot/templates/admin/update_permissions.html
@@ -1,17 +1,20 @@
-{% extends "admin/base_site.html" %}
-{% load i18n l10n admin_urls static %}
+{% extends 'admin/base_site.html' %}
+{% load admin_urls %}
+{% load l10n %}
+{% load i18n %}
+{% load static %}
 
 
 {% block extrahead %}
-{{ block.super }}
-<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
-{{ form.media }}
+  {{ block.super }}
+  <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+  {{ form.media }}
 {% endblock extrahead %}
 
 
 {% block extrastyle %}
-{{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}" />
 {% endblock extrastyle %}
 
 
@@ -19,38 +22,42 @@
 
 
 {% block breadcrumbs %}
-<div class="breadcrumbs">
-    <a href="{% url 'admin:index' %}">{% trans "Home" %}</a>
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
     &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
     &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
-    &rsaquo; {% trans "Update permissions" %}
-</div>
+    &rsaquo; {% trans 'Update permissions' %}
+  </div>
 {% endblock breadcrumbs %}
 
 
 {% block content %}
-<p>{% blocktrans %}Permissions will be updated for the selected {{ objects_name }}.{% endblocktrans %}</p>
+  <p>
+    {% blocktrans %}
+      Permissions will be updated for the selected {{ objects_name }}.
+    {% endblocktrans %}
+  </p>
 
-<form action="" method="POST" id="update-permissions">
+  <form action="" method="POST" id="update-permissions">
     {% csrf_token %}
 
     {% for field in form.hidden_fields %}
-        {{ field }}
+      {{ field }}
     {% endfor %}
 
     {% for fieldset in adminform %}
-        {% include "admin/includes/fieldset.html" %}
+      {% include 'admin/includes/fieldset.html' %}
     {% endfor %}
 
     {% for obj in queryset %}
-        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
+      <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}" />
     {% endfor %}
     <input type="hidden" name="action" value="update_permissions" />
     <input type="hidden" name="post" value="yes" />
 
     <div class="submit-row">
-        <input type="submit" value="{% trans 'Add permissions' %}" class="default" />
-        <input type="submit" value="{% trans 'Remove permissions' %}" name="remove_permissions" />
+      <input type="submit" value="{% trans 'Add permissions' %}" class="default" />
+      <input type="submit" value="{% trans 'Remove permissions' %}" name="remove_permissions" />
     </div>
-</form>
+  </form>
 {% endblock content %}


### PR DESCRIPTION
Only superusers can edit it, so only show the link to them.

I've updated the HTML indentation as part of this PR, so https://github.com/blancltd/django-groot/pull/16/files?w=1 might give a better idea of the changes.